### PR TITLE
Support Jekyll versions 3.0 and above

### DIFF
--- a/jekyll-tfidf-related-posts.gemspec
+++ b/jekyll-tfidf-related-posts.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ["lib"]
 
-	spec.add_dependency "jekyll", "~> 3.0"
+  spec.add_dependency "jekyll", ">= 3.0"
   spec.add_dependency "stopwords-filter", "~> 0.4"
   spec.add_dependency "fast-stemmer", "~> 1.0"
   spec.add_dependency "pqueue", "~> 2.1"


### PR DESCRIPTION
I find this gem is better than jekyll-related-posts and it'd be good to use it with Jekyll versions higher than 3.0.